### PR TITLE
Reset button and script to remove QPalette UI error lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build*
+source/INQNET_GUI.pro.user
+*.h5

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -225,6 +225,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     ui->ps_disconnect_button->setEnabled(false);
     ui->ps_start_button->setEnabled(false);
     ui->ps_stop_button->setEnabled(false);
+
+    connect(ui->actionReset, SIGNAL(triggered()), this, SLOT(resetButton_clicked()));
 }
 
 //////////////////////////////////////////////////////////
@@ -2368,7 +2370,8 @@ void MainWindow::closeEvent(QCloseEvent *event)
     event->accept();
 }
 
-void MainWindow::resetButton_clicked() {
+void MainWindow::resetButton_clicked()
+{
     // Array of the plots that will be cleared
     // There are currently 9 plots, so that number must be updated in the loop as well if it changes
     QCustomPlot *ui_plots[9] = {ui->QKD_H1_results, ui->QKD_H2_results, ui->QKD_H3_results,
@@ -2381,19 +2384,4 @@ void MainWindow::resetButton_clicked() {
             }
             ui_plots[p]->replot();
     }
-}
-
-void MainWindow::on_resetButton_1_clicked()
-{
-    resetButton_clicked();
-}
-
-void MainWindow::on_resetButton_2_clicked()
-{
-    resetButton_clicked();
-}
-
-void MainWindow::on_resetButton_3_clicked()
-{
-    resetButton_clicked();
 }

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -2367,3 +2367,33 @@ void MainWindow::closeEvent(QCloseEvent *event)
 
     event->accept();
 }
+
+void MainWindow::resetButton_clicked() {
+    // Array of the plots that will be cleared
+    // There are currently 9 plots, so that number must be updated in the loop as well if it changes
+    QCustomPlot *ui_plots[9] = {ui->QKD_H1_results, ui->QKD_H2_results, ui->QKD_H3_results,
+                               ui->Early_results, ui->Late_results, ui->Phase_results,
+                               ui->qkd_errorplot, ui->qkd_siftedplot, ui->qkd_siftedplot_2};
+
+    for (int p = 0; p < 9; p++) {
+            for (int g = 0; g < ui_plots[p]->graphCount(); g++) {
+                ui_plots[p]->graph(g)->data()->clear();
+            }
+            ui_plots[p]->replot();
+    }
+}
+
+void MainWindow::on_resetButton_1_clicked()
+{
+    resetButton_clicked();
+}
+
+void MainWindow::on_resetButton_2_clicked()
+{
+    resetButton_clicked();
+}
+
+void MainWindow::on_resetButton_3_clicked()
+{
+    resetButton_clicked();
+}

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -466,6 +466,11 @@ private slots:
     void PowerSupplyDisconnect(void);
     void PowerSupplyConnect(void);
 
+    void resetButton_clicked();
+    void on_resetButton_1_clicked();
+    void on_resetButton_2_clicked();
+    void on_resetButton_3_clicked();
+
 private:
     Ui::MainWindow *ui;
     Swabian s;

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -467,9 +467,6 @@ private slots:
     void PowerSupplyConnect(void);
 
     void resetButton_clicked();
-    void on_resetButton_1_clicked();
-    void on_resetButton_2_clicked();
-    void on_resetButton_3_clicked();
 
 private:
     Ui::MainWindow *ui;
@@ -535,18 +532,18 @@ private:
     bool qubitsfromDBloaded = false;
     int QKD_DB_ON=0;
 
-    QVector<double> datah5okA;
-    QVector<double> datah5errA;
-    QVector<double> datah5randA;
-    QVector<double> datah5bkgndA;
-    QVector<double> datah5okB;
-    QVector<double> datah5errB;
-    QVector<double> datah5randB;
-    QVector<double> datah5bkgndB;
-    QVector<double> datah5okC;
-    QVector<double> datah5errC;
-    QVector<double> datah5randC;
-    QVector<double> datah5bkgndC;
+    QVector<int> datah5okA;
+    QVector<int> datah5errA;
+    QVector<int> datah5randA;
+    QVector<int> datah5bkgndA;
+    QVector<int> datah5okB;
+    QVector<int> datah5errB;
+    QVector<int> datah5randB;
+    QVector<int> datah5bkgndB;
+    QVector<int> datah5okC;
+    QVector<int> datah5errC;
+    QVector<int> datah5randC;
+    QVector<int> datah5bkgndC;
 
     int rof[18];
     double thresholds[18];
@@ -560,6 +557,7 @@ private:
     QLCDNumber *rate_widgets[18];
 
     bool HDF5File_created=false;
+
 signals:
     void main_SaveAndValues(int and1, int and2, int and3, int orgate, int bsm1, int bsm2, float andTime, int delayline);
     void main_SaveRateValues( int Ra1, int Ra2, int Ra3, int Rb1, int Rb2, int Rb3, int Rc1, int Rc2, int Rc3, float hist_adqtime);

--- a/source/mainwindow.ui
+++ b/source/mainwindow.ui
@@ -51,7 +51,7 @@
        <bool>true</bool>
       </property>
       <property name="currentIndex">
-       <number>4</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="tab1">
        <property name="autoFillBackground">
@@ -1503,6 +1503,13 @@
              <enum>QLayout::SetMinimumSize</enum>
             </property>
             <item>
+             <widget class="QPushButton" name="resetButton_1">
+              <property name="text">
+               <string>Reset</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -1739,6 +1746,13 @@
           <property name="sizeConstraint">
            <enum>QLayout::SetMinimumSize</enum>
           </property>
+          <item>
+           <widget class="QPushButton" name="resetButton_2">
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
           <item>
            <spacer name="verticalSpacer_20">
             <property name="orientation">
@@ -2364,176 +2378,183 @@
        <attribute name="title">
         <string>QKD stats</string>
        </attribute>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_17">
-           <item>
-            <widget class="QCustomPlot" name="qkd_siftedplot_2" native="true">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <layout class="QHBoxLayout" name="horizontalLayout_48"/>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCustomPlot" name="qkd_errorplot" native="true">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <layout class="QHBoxLayout" name="horizontalLayout_45"/>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCustomPlot" name="qkd_siftedplot" native="true">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <layout class="QHBoxLayout" name="horizontalLayout_46"/>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_16">
-           <item>
-            <spacer name="verticalSpacer_16">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <spacer name="verticalSpacer_12">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_139">
-             <property name="palette">
-              <palette>
-               <active>
-                <colorrole role="WindowText">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>174</red>
-                   <green>174</green>
-                   <blue>174</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-               </active>
-               <inactive>
-                <colorrole role="WindowText">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>174</red>
-                   <green>174</green>
-                   <blue>174</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-               </inactive>
-               <disabled>
-                <colorrole role="WindowText">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>190</red>
-                   <green>190</green>
-                   <blue>190</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-               </disabled>
-              </palette>
-             </property>
-             <property name="text">
-              <string>ERROR TIME</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_138">
-             <property name="palette">
-              <palette>
-               <active>
-                <colorrole role="WindowText">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>255</red>
-                   <green>0</green>
-                   <blue>0</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-               </active>
-               <inactive>
-                <colorrole role="WindowText">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>255</red>
-                   <green>0</green>
-                   <blue>0</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-               </inactive>
-               <disabled>
-                <colorrole role="WindowText">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>190</red>
-                   <green>190</green>
-                   <blue>190</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-               </disabled>
-              </palette>
-             </property>
-             <property name="text">
-              <string>ERROR PHASE</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="verticalSpacer_15">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-        </layout>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_17">
+          <item>
+           <widget class="QCustomPlot" name="qkd_siftedplot_2" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_48"/>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCustomPlot" name="qkd_errorplot" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_45"/>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCustomPlot" name="qkd_siftedplot" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_46"/>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_16">
+          <item>
+           <widget class="QPushButton" name="resetButton_3">
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_16">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_12">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_139">
+            <property name="palette">
+             <palette>
+              <active>
+               <colorrole role="WindowText">
+                <brush brushstyle="SolidPattern">
+                 <color alpha="255">
+                  <red>174</red>
+                  <green>174</green>
+                  <blue>174</blue>
+                 </color>
+                </brush>
+               </colorrole>
+              </active>
+              <inactive>
+               <colorrole role="WindowText">
+                <brush brushstyle="SolidPattern">
+                 <color alpha="255">
+                  <red>174</red>
+                  <green>174</green>
+                  <blue>174</blue>
+                 </color>
+                </brush>
+               </colorrole>
+              </inactive>
+              <disabled>
+               <colorrole role="WindowText">
+                <brush brushstyle="SolidPattern">
+                 <color alpha="255">
+                  <red>190</red>
+                  <green>190</green>
+                  <blue>190</blue>
+                 </color>
+                </brush>
+               </colorrole>
+              </disabled>
+             </palette>
+            </property>
+            <property name="text">
+             <string>ERROR TIME</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_138">
+            <property name="palette">
+             <palette>
+              <active>
+               <colorrole role="WindowText">
+                <brush brushstyle="SolidPattern">
+                 <color alpha="255">
+                  <red>255</red>
+                  <green>0</green>
+                  <blue>0</blue>
+                 </color>
+                </brush>
+               </colorrole>
+              </active>
+              <inactive>
+               <colorrole role="WindowText">
+                <brush brushstyle="SolidPattern">
+                 <color alpha="255">
+                  <red>255</red>
+                  <green>0</green>
+                  <blue>0</blue>
+                 </color>
+                </brush>
+               </colorrole>
+              </inactive>
+              <disabled>
+               <colorrole role="WindowText">
+                <brush brushstyle="SolidPattern">
+                 <color alpha="255">
+                  <red>190</red>
+                  <green>190</green>
+                  <blue>190</blue>
+                 </color>
+                </brush>
+               </colorrole>
+              </disabled>
+             </palette>
+            </property>
+            <property name="text">
+             <string>ERROR PHASE</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_15">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </widget>
       <widget class="QWidget" name="tab_4">
        <property name="autoFillBackground">
@@ -2643,7 +2664,7 @@
      <x>0</x>
      <y>0</y>
      <width>1500</width>
-     <height>23</height>
+     <height>25</height>
     </rect>
    </property>
    <property name="font">

--- a/source/mainwindow.ui
+++ b/source/mainwindow.ui
@@ -51,7 +51,7 @@
        <bool>true</bool>
       </property>
       <property name="currentIndex">
-       <number>2</number>
+       <number>3</number>
       </property>
       <widget class="QWidget" name="tab1">
        <property name="autoFillBackground">
@@ -1503,13 +1503,6 @@
              <enum>QLayout::SetMinimumSize</enum>
             </property>
             <item>
-             <widget class="QPushButton" name="resetButton_1">
-              <property name="text">
-               <string>Reset</string>
-              </property>
-             </widget>
-            </item>
-            <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -1746,13 +1739,6 @@
           <property name="sizeConstraint">
            <enum>QLayout::SetMinimumSize</enum>
           </property>
-          <item>
-           <widget class="QPushButton" name="resetButton_2">
-            <property name="text">
-             <string>Reset</string>
-            </property>
-           </widget>
-          </item>
           <item>
            <spacer name="verticalSpacer_20">
             <property name="orientation">
@@ -2419,13 +2405,6 @@
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_16">
           <item>
-           <widget class="QPushButton" name="resetButton_3">
-            <property name="text">
-             <string>Reset</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <spacer name="verticalSpacer_16">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -2696,12 +2675,16 @@
     <addaction name="actionLoad_state"/>
     <addaction name="separator"/>
     <addaction name="menuLoad_Qubits"/>
+    <addaction name="separator"/>
+    <addaction name="actionSave_Data"/>
    </widget>
    <widget class="QMenu" name="menuQKD_param">
     <property name="title">
      <string>Edit</string>
     </property>
     <addaction name="actionQKD"/>
+    <addaction name="separator"/>
+    <addaction name="actionReset"/>
    </widget>
    <widget class="QMenu" name="menuConnect">
     <property name="title">
@@ -2718,12 +2701,12 @@
   </widget>
   <action name="actionSave_state">
    <property name="text">
-    <string>Save state</string>
+    <string>Save State</string>
    </property>
   </action>
   <action name="actionLoad_state">
    <property name="text">
-    <string>Load state</string>
+    <string>Load State</string>
    </property>
   </action>
   <action name="actionQKD">
@@ -2739,6 +2722,16 @@
   <action name="actionDisconnect">
    <property name="text">
     <string>Disconnect</string>
+   </property>
+  </action>
+  <action name="actionReset">
+   <property name="text">
+    <string>Reset</string>
+   </property>
+  </action>
+  <action name="actionSave_Data">
+   <property name="text">
+    <string>Save Data</string>
    </property>
   </action>
  </widget>

--- a/source/qkd_param.ui
+++ b/source/qkd_param.ui
@@ -95,18 +95,24 @@
         </widget>
        </item>
        <item>
-        <widget class="QSpinBox" name="QKD_phA">
+        <widget class="QDoubleSpinBox" name="QKD_phA">
          <property name="styleSheet">
           <string notr="true">color: rgb(255, 255, 255);</string>
+         </property>
+         <property name="prefix">
+          <string/>
          </property>
          <property name="suffix">
           <string> [ps]</string>
          </property>
-         <property name="minimum">
-          <number>1</number>
+         <property name="decimals">
+          <number>3</number>
          </property>
          <property name="maximum">
-          <number>3000</number>
+          <double>3000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>1.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -240,18 +246,21 @@
         </widget>
        </item>
        <item>
-        <widget class="QSpinBox" name="QKD_phB">
+        <widget class="QDoubleSpinBox" name="QKD_phB">
          <property name="styleSheet">
           <string notr="true">color: rgb(255, 255, 255);</string>
          </property>
          <property name="suffix">
           <string> [ps]</string>
          </property>
-         <property name="minimum">
-          <number>1</number>
+         <property name="decimals">
+          <number>3</number>
          </property>
          <property name="maximum">
-          <number>3000</number>
+          <double>3000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>1.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -385,12 +394,21 @@
         </widget>
        </item>
        <item>
-        <widget class="QSpinBox" name="QKD_phC">
+        <widget class="QDoubleSpinBox" name="QKD_phC">
          <property name="styleSheet">
           <string notr="true">color: rgb(255, 255, 255);</string>
          </property>
          <property name="suffix">
           <string> [ps]</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="maximum">
+          <double>3000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>1.000000000000000</double>
          </property>
         </widget>
        </item>

--- a/source/rm_error_QPalette.sh
+++ b/source/rm_error_QPalette.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Use this script to remove the lines producing "error: ‘PlaceholderText’ is not a member of ‘QPalette’". Run ./rm_error_QPalette [line numbers separated by spaces] . Example: "./rm_error_QPalette 1001 1003 1002"
+
+set -e
+
+if [ $# -eq 0 ]
+	then
+		echo "error: no arguments supplied"
+		exit 1
+fi
+
+# used to check that all args are integer
+re='^[0-9]+$'
+
+# quit if we get a non-integer argument
+for var in "$@"; do
+	if ! [[ "$var" =~ $re ]]
+	then
+		echo "error: argument $var NaN"
+		exit 2
+	fi
+done
+
+# sort the arguments in reverse order, so we can remove the last lines first
+sorted_nums=$(for var in "$@"; do
+	echo "$var"
+done | sort -nr)
+
+# remove the lines
+echo "$sorted_nums" | while read line; do
+	echo "Removing line $line"
+	sed -i "${line}d" ./ui_mainwindow.h
+done


### PR DESCRIPTION
- The phase time in QKD params can be changed as a decimal now.
- Added a shell script to remove the QPalette errors that arise after editing the ui, so that you can compile without the errors . Use it by supplying the line numbers that should be removed. It doesn't check that these are the correct line numbers so be careful. Will update later with a help option.
- Added reset buttons that clear the data from _every_ plot. It would be nice to verify that this makes the program run smoothly again after it has been open and collecting data for a long time. I will update this in the future to better utilize signal and slots by connecting the on_clicked signal of each button to a single reset slot to clean up the redundancy.

Submitting now for testing.